### PR TITLE
Fix unavailable generation entity from stopping render

### DIFF
--- a/src/elec-sankey.ts
+++ b/src/elec-sankey.ts
@@ -580,10 +580,11 @@ export class ElecSankey extends LitElement {
     const divArray: TemplateResult[] = [];
 
     const startTerminatorY = 0;
-
+    let phantomRate = 0;
     const routes = structuredClone(this.generationInRoutes);
     if (this._phantomGenerationInRoute !== undefined) {
       routes.phantom = this._phantomGenerationInRoute;
+      phantomRate = this._phantomGenerationInRoute.rate;
     }
     let i = 0;
     // eslint-disable-next-line guard-for-in
@@ -591,10 +592,10 @@ export class ElecSankey extends LitElement {
       if (Object.prototype.hasOwnProperty.call(routes, key)) {
         // const friendlyName = routes.text;
         let width = 0;
-        const rate = routes[key].rate;
+        const rate = routes[key].rate || 0; // Handle undefined (NaN) rates.
         // Most of the time, if the rate is zero, we don't want to draw it.
-        // Exception is if we have > phantom source.
-        if (rate || routes.phantom.rate > 0) {
+        // Exception is if we have a >0 phantom source.
+        if (rate || phantomRate > 0) {
           width = this._rateToWidth(rate);
           svgArray.push(
             renderFlowByCorners(


### PR DESCRIPTION
There was an issue where if an entity became unavailable, an error would occur when trying to draw it, causing the full draw to fail and leaving an empty card on the HA UI.

This PR solves the issue by allowing the draw to continue, even if phantom.rate has not been defined.

Fixes #5